### PR TITLE
remove merge artifacts from settings file

### DIFF
--- a/SSEServer/settings.py
+++ b/SSEServer/settings.py
@@ -81,16 +81,6 @@ WSGI_APPLICATION = 'SSEServer.wsgi.application'
 
 DATABASES = {
     'default': {
-<<<<<<< HEAD
-        'ENGINE': 'django.db.backends.sqlite3', # for local test
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'), # for local test
-        #'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        #'NAME': os.environ['DB_NAME'],# database name
-        #'USER': os.environ['DB_USER'], # user name
-        #'PASSWORD': os.environ['DB_PASSWORD'], # user password
-        #'HOST': os.environ['DB_HOST'], # postgres server
-        #'PORT': os.environ['DB_PORT'],  # postgres port
-=======
         #'ENGINE': 'django.db.backends.sqlite3', # for local test
         #'NAME': os.path.join(BASE_DIR, 'db.sqlite3'), # for local test
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
@@ -99,7 +89,6 @@ DATABASES = {
         'PASSWORD': os.environ['DB_PASSWORD'], # user password
         'HOST': os.environ['DB_HOST'], # postgres server
         'PORT': os.environ['DB_PORT'],  # postgres port
->>>>>>> f96315b4173c5b4889430ed8a4801124f831b309
     }
 }
 


### PR DESCRIPTION
Trying to run the server results in it crashing with the following error:

```
sse-web_1     |   File "/SSEServer/SSEServer/settings.py", line 84
sse-web_1     |     <<<<<<< HEAD
sse-web_1     |      ^
sse-web_1     | SyntaxError: invalid syntax
```

it looks some merge conflicts where not cleaned up before pushing to
github.

this commit removes what looks like some development settings and
leaves the settings that are suitable for deployment