### PR TITLE
increase keyId max_length to 255

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -5,13 +5,13 @@ from django.db import models
 class CipherText(models.Model):
 	jsonId = models.CharField(max_length=300)
 	data = models.TextField()
-	keyId = models.CharField(max_length=20)
+	keyId = models.CharField(max_length=255)
 	def __str__(self):
 		return '%s %s' % (self.jsonId, self.data, self.keyId)
 
 class Map(models.Model):
 	address = models.CharField(max_length=300)
 	value = models.CharField(max_length=300) # file identifiers
-	keyId = models.CharField(max_length=20)
+	keyId = models.CharField(max_length=255)
 	def __str__(self):
 		return '%s %s' % (self.address, self.value, self.keyId) 	


### PR DESCRIPTION
Increase the maximum length of the keyID field inordeer to support more
key formats (specifically UUID keys)

The value 255 was chosen as according to the Django documentation this
is the maximum length for unique VARCHAR columns on MySQL:
https://docs.djangoproject.com/en/dev/ref/databases/#character-fields